### PR TITLE
Update xcp-prepare-windows-for-xcp-smb.adoc

### DIFF
--- a/xcp-prepare-windows-for-xcp-smb.adoc
+++ b/xcp-prepare-windows-for-xcp-smb.adoc
@@ -38,6 +38,7 @@ members of this group can read files while bypassing the security rules,
 regardless of any permissions that protect those files.
 **	If the user is not part of “Backup Operators” group in source system, the user
 must have read access.
+**  If the copy / sync updates ACL's of files, additional privleges may be required.  Be sure the user is a member of BUILTIN\Administrators
 
 NOTE: Write permission is required in the source storage system for supporting the XCP option `- preserve-atime`.
 


### PR DESCRIPTION
There was no caveat that additional permissions are needed for ACL sync.  its important that they are not finding this out after going through provisioning.